### PR TITLE
Make response mandatory

### DIFF
--- a/examples/authorization.cr
+++ b/examples/authorization.cr
@@ -23,15 +23,15 @@ builder = Swagger::Builder.new(
 )
 
 builder.add(Swagger::Controller.new("Auth", "Authorization", [
-  Swagger::Action.new("get", "/access_token", "Get Access Token"),
+  Swagger::Action.new("get", "/access_token", [Swagger::Response.new("200", "Success response")], "Get Access Token"),
 ], external_docs: Swagger::ExternalDocs.new("http://auth.example.com/private_token", "See Details")))
 
 builder.add(Swagger::Controller.new("Users", "User Resources", [
-  Swagger::Action.new("get", "/users", "List users", parameters: [
+  Swagger::Action.new("get", "/users", [Swagger::Response.new("200", "Success response")], "List users", parameters: [
     Swagger::Parameter.new("page", "query", "integer", "Current page"),
     Swagger::Parameter.new("limit", "query", "integer", "How many items to return at one time (max 100)"),
   ], authorization: true),
-  Swagger::Action.new("get", "/users/{id}", "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
+  Swagger::Action.new("get", "/users/{id}", description: "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
     Swagger::Response.new("200", "Success response"),
     Swagger::Response.new("404", "Not found user"),
   ], authorization: true),

--- a/examples/frameworks/kemal.cr
+++ b/examples/frameworks/kemal.cr
@@ -55,13 +55,13 @@ builder = Swagger::Builder.new(
 )
 
 builder.add(Swagger::Controller.new("Users", "User Resources", [
-  Swagger::Action.new("get", "/users", "List users", parameters: [
+  Swagger::Action.new("get", "/users", description: "List users", parameters: [
     Swagger::Parameter.new("page", "query", "integer", "Current page", default_value: 1),
     Swagger::Parameter.new("limit", "query", "integer", "How many items to return at one time (max 100)", default_value: 10),
   ], responses: [
     Swagger::Response.new("200", "Success response"),
   ]),
-  Swagger::Action.new("get", "/users/{id}", "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
+  Swagger::Action.new("get", "/users/{id}", description: "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
     Swagger::Response.new("200", "Success response"),
     Swagger::Response.new("404", "Not found user"),
   ]),
@@ -75,7 +75,7 @@ builder.add(Swagger::Controller.new("Users", "User Resources", [
       Swagger::Response.new("404", "Not found user"),
     ]
   ),
-  Swagger::Action.new("delete", "/users/{id}", "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
+  Swagger::Action.new("delete", "/users/{id}", description: "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
     Swagger::Response.new("200", "Success response"),
     Swagger::Response.new("404", "Not found user"),
   ]),

--- a/examples/simple.cr
+++ b/examples/simple.cr
@@ -19,15 +19,15 @@ builder.add(Swagger::Object.new("User", "object", [
 ]))
 
 builder.add(Swagger::Controller.new("Users", "User Resources", [
-  Swagger::Action.new("get", "/users", "List users", parameters: [
+  Swagger::Action.new("get", "/users", [Swagger::Response.new("200", "Success response")], "List users", parameters: [
     Swagger::Parameter.new("page", "query", "integer", "Current page", default_value: 1, format: "int32"),
     Swagger::Parameter.new("limit", "query", "integer", "How many items to return at one time (max 100)", default_value: 50, format: "int32"),
   ]),
-  Swagger::Action.new("get", "/users/{id}", "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
+  Swagger::Action.new("get", "/users/{id}", description: "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
     Swagger::Response.new("200", "Success response"),
     Swagger::Response.new("404", "Not found user"),
   ], request: Swagger::Request.new("User")),
-  Swagger::Action.new("post", "/users", "Create user",
+  Swagger::Action.new("post", "/users", description: "Create user",
     request: Swagger::Request.new([
       Swagger::Property.new("username", required: true, description: "The name of user"),
       Swagger::Property.new("email", "string", required: true, description: "Email"),
@@ -40,7 +40,7 @@ builder.add(Swagger::Controller.new("Users", "User Resources", [
       Swagger::Response.new("404", "Not found user"),
     ]
   ),
-  Swagger::Action.new("get", "/user/{id}", "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
+  Swagger::Action.new("get", "/user/{id}", description: "Get user by id", parameters: [Swagger::Parameter.new("id", "path")], responses: [
     Swagger::Response.new("200", "Success response"),
     Swagger::Response.new("404", "Not found user"),
   ], deprecated: true),

--- a/spec/swagger/action_helper.cr
+++ b/spec/swagger/action_helper.cr
@@ -1,0 +1,4 @@
+require "spec"
+require "../../src/swagger/response"
+
+OK_RESPONSE = [Swagger::Response.new "200", "OK"]

--- a/spec/swagger/action_spec.cr
+++ b/spec/swagger/action_spec.cr
@@ -1,14 +1,13 @@
-require "../spec_helper"
+require "./action_helper"
+require "../../src/swagger/action"
 
 describe Swagger::Action do
-  ok_response = [Swagger::Response.new "200", "OK"]
-
   describe "#new" do
     it "should works" do
-      raw = Swagger::Action.new("get", "/users", ok_response)
+      raw = Swagger::Action.new("get", "/users", OK_RESPONSE)
       raw.method.should eq "get"
       raw.route.should eq "/users"
-      raw.responses.should eq ok_response
+      raw.responses.should eq OK_RESPONSE
       raw.summary.should be_nil
       raw.description.should be_nil
       raw.parameters.should be_nil
@@ -18,13 +17,13 @@ describe Swagger::Action do
     end
 
     it "should stored downcase method" do
-      raw = Swagger::Action.new("GET", "/users", ok_response)
+      raw = Swagger::Action.new("GET", "/users", OK_RESPONSE)
       raw.method.should eq "get"
     end
 
     {% for ivar in Swagger::Objects::PathItem::METHODS %}
       it "should define {{ ivar.id }} method" do
-        raw = Swagger::Action.new("{{ ivar.id }}", "/users", ok_response)
+        raw = Swagger::Action.new("{{ ivar.id }}", "/users", OK_RESPONSE)
         raw.method.should eq "{{ ivar.id }}"
         raw.route.should eq "/users"
       end
@@ -32,7 +31,7 @@ describe Swagger::Action do
 
     it "throws an exception with undefined method" do
       expect_raises Swagger::UndefinedMethod do
-        Swagger::Action.new("fake", "/users", ok_response)
+        Swagger::Action.new("fake", "/users", OK_RESPONSE)
       end
     end
   end

--- a/spec/swagger/action_spec.cr
+++ b/spec/swagger/action_spec.cr
@@ -1,28 +1,30 @@
 require "../spec_helper"
 
 describe Swagger::Action do
+  ok_response = [Swagger::Response.new "200", "OK"]
+
   describe "#new" do
     it "should works" do
-      raw = Swagger::Action.new("get", "/users")
+      raw = Swagger::Action.new("get", "/users", ok_response)
       raw.method.should eq "get"
       raw.route.should eq "/users"
+      raw.responses.should eq ok_response
       raw.summary.should be_nil
       raw.description.should be_nil
       raw.parameters.should be_nil
       raw.request.should be_nil
-      raw.responses.should be_nil
       raw.authorization.should be_false
       raw.deprecated.should be_false
     end
 
     it "should stored downcase method" do
-      raw = Swagger::Action.new("GET", "/users")
+      raw = Swagger::Action.new("GET", "/users", ok_response)
       raw.method.should eq "get"
     end
 
     {% for ivar in Swagger::Objects::PathItem::METHODS %}
       it "should define {{ ivar.id }} method" do
-        raw = Swagger::Action.new("{{ ivar.id }}", "/users")
+        raw = Swagger::Action.new("{{ ivar.id }}", "/users", ok_response)
         raw.method.should eq "{{ ivar.id }}"
         raw.route.should eq "/users"
       end
@@ -30,7 +32,7 @@ describe Swagger::Action do
 
     it "throws an exception with undefined method" do
       expect_raises Swagger::UndefinedMethod do
-        Swagger::Action.new("fake", "/users")
+        Swagger::Action.new("fake", "/users", ok_response)
       end
     end
   end

--- a/spec/swagger/controller_spec.cr
+++ b/spec/swagger/controller_spec.cr
@@ -1,6 +1,8 @@
 require "../spec_helper"
 
 describe Swagger::Controller do
+  ok_response = [Swagger::Response.new "200", "OK"]
+
   describe "#new" do
     it "should works without any action" do
       raw = Swagger::Controller.new("Users", "User APIs")
@@ -12,11 +14,11 @@ describe Swagger::Controller do
 
     it "should works with actions" do
       raw = Swagger::Controller.new("Users", "User APIs", [
-        Swagger::Action.new("get", "/users", "List Users"),
+        Swagger::Action.new("get", "/users", ok_response, "List Users"),
       ])
       raw.name.should eq "Users"
       raw.description.should eq "User APIs"
-      raw.actions.should eq([Swagger::Action.new("get", "/users", "List Users")])
+      raw.actions.should eq([Swagger::Action.new("get", "/users", ok_response, "List Users")])
       raw.external_docs.should be_nil
     end
   end

--- a/spec/swagger/controller_spec.cr
+++ b/spec/swagger/controller_spec.cr
@@ -1,8 +1,7 @@
-require "../spec_helper"
+require "./action_helper"
+require "../../src/swagger/controller"
 
 describe Swagger::Controller do
-  ok_response = [Swagger::Response.new "200", "OK"]
-
   describe "#new" do
     it "should works without any action" do
       raw = Swagger::Controller.new("Users", "User APIs")
@@ -14,11 +13,11 @@ describe Swagger::Controller do
 
     it "should works with actions" do
       raw = Swagger::Controller.new("Users", "User APIs", [
-        Swagger::Action.new("get", "/users", ok_response, "List Users"),
+        Swagger::Action.new("get", "/users", OK_RESPONSE, "List Users"),
       ])
       raw.name.should eq "Users"
       raw.description.should eq "User APIs"
-      raw.actions.should eq([Swagger::Action.new("get", "/users", ok_response, "List Users")])
+      raw.actions.should eq([Swagger::Action.new("get", "/users", OK_RESPONSE, "List Users")])
       raw.external_docs.should be_nil
     end
   end

--- a/spec/swagger/objects/operation_spec.cr
+++ b/spec/swagger/objects/operation_spec.cr
@@ -1,19 +1,21 @@
 require "../../spec_helper"
 
 describe Swagger::Objects::Operation do
+  swagger_ok_response = {"200" => Swagger::Objects::Response.new "OK"}
+
   describe ".from" do
     pending
   end
 
   describe "#new" do
     it "should works" do
-      raw = Swagger::Objects::Operation.new
+      raw = Swagger::Objects::Operation.new swagger_ok_response
+      raw.responses.should eq swagger_ok_response
       raw.summary.should be_nil
       raw.description.should be_nil
       raw.tags.should be_nil
       raw.parameters.should be_nil
       raw.request_body.should be_nil
-      raw.responses.should be_nil
       raw.deprecated.should be_false
       raw.security.should be_nil
 
@@ -26,13 +28,13 @@ describe Swagger::Objects::Operation do
 
   describe "#to_json" do
     it "should return default hash string" do
-      raw = Swagger::Objects::Operation.new
-      raw.to_json.should eq %Q{{"deprecated":false}}
+      raw = Swagger::Objects::Operation.new swagger_ok_response
+      raw.to_json.should eq %Q{{"responses":{"200":{"description":"OK"}},"deprecated":false}}
     end
 
     it "should returns OpenAPI spec Link json string" do
-      raw = Swagger::Objects::Operation.new(request_body: Swagger::Objects::RequestBody.new)
-      raw.to_json.should eq %Q{{"requestBody":{"required":false},"deprecated":false}}
+      raw = Swagger::Objects::Operation.new(swagger_ok_response, request_body: Swagger::Objects::RequestBody.new)
+      raw.to_json.should eq %Q{{"requestBody":{"required":false},"responses":{"200":{"description":"OK"}},"deprecated":false}}
     end
   end
 end

--- a/spec/swagger/objects/operation_spec.cr
+++ b/spec/swagger/objects/operation_spec.cr
@@ -1,16 +1,15 @@
-require "../../spec_helper"
+require "./response_helper"
+require "../../../src/swagger/objects/operation"
 
 describe Swagger::Objects::Operation do
-  swagger_ok_response = {"200" => Swagger::Objects::Response.new "OK"}
-
   describe ".from" do
     pending
   end
 
   describe "#new" do
     it "should works" do
-      raw = Swagger::Objects::Operation.new swagger_ok_response
-      raw.responses.should eq swagger_ok_response
+      raw = Swagger::Objects::Operation.new SWAGGER_OK_RESPONSE
+      raw.responses.should eq SWAGGER_OK_RESPONSE
       raw.summary.should be_nil
       raw.description.should be_nil
       raw.tags.should be_nil
@@ -28,12 +27,12 @@ describe Swagger::Objects::Operation do
 
   describe "#to_json" do
     it "should return default hash string" do
-      raw = Swagger::Objects::Operation.new swagger_ok_response
+      raw = Swagger::Objects::Operation.new SWAGGER_OK_RESPONSE
       raw.to_json.should eq %Q{{"responses":{"200":{"description":"OK"}},"deprecated":false}}
     end
 
     it "should returns OpenAPI spec Link json string" do
-      raw = Swagger::Objects::Operation.new(swagger_ok_response, request_body: Swagger::Objects::RequestBody.new)
+      raw = Swagger::Objects::Operation.new(SWAGGER_OK_RESPONSE, request_body: Swagger::Objects::RequestBody.new)
       raw.to_json.should eq %Q{{"requestBody":{"required":false},"responses":{"200":{"description":"OK"}},"deprecated":false}}
     end
   end

--- a/spec/swagger/objects/path_item_spec.cr
+++ b/spec/swagger/objects/path_item_spec.cr
@@ -1,8 +1,7 @@
-require "../../spec_helper"
+require "./response_helper"
+require "../../../src/swagger/objects/path_item"
 
 describe Swagger::Objects::PathItem do
-  swagger_ok_response = {"200" => Swagger::Objects::Response.new "OK"}
-
   describe "#new" do
     it "should works" do
       raw = Swagger::Objects::PathItem.new
@@ -23,10 +22,10 @@ describe Swagger::Objects::PathItem do
   describe "#add" do
     it "should works" do
       raw = Swagger::Objects::PathItem.new
-      raw.add("get", Swagger::Objects::Operation.new swagger_ok_response)
+      raw.add("get", Swagger::Objects::Operation.new SWAGGER_OK_RESPONSE)
       raw.summary.should be_nil
       raw.description.should be_nil
-      raw.get.should eq Swagger::Objects::Operation.new swagger_ok_response
+      raw.get.should eq Swagger::Objects::Operation.new SWAGGER_OK_RESPONSE
       raw.put.should be_nil
       raw.post.should be_nil
       raw.delete.should be_nil

--- a/spec/swagger/objects/path_item_spec.cr
+++ b/spec/swagger/objects/path_item_spec.cr
@@ -1,6 +1,8 @@
 require "../../spec_helper"
 
 describe Swagger::Objects::PathItem do
+  swagger_ok_response = {"200" => Swagger::Objects::Response.new "OK"}
+
   describe "#new" do
     it "should works" do
       raw = Swagger::Objects::PathItem.new
@@ -21,10 +23,10 @@ describe Swagger::Objects::PathItem do
   describe "#add" do
     it "should works" do
       raw = Swagger::Objects::PathItem.new
-      raw.add("get", Swagger::Objects::Operation.new)
+      raw.add("get", Swagger::Objects::Operation.new swagger_ok_response)
       raw.summary.should be_nil
       raw.description.should be_nil
-      raw.get.should eq Swagger::Objects::Operation.new
+      raw.get.should eq Swagger::Objects::Operation.new swagger_ok_response
       raw.put.should be_nil
       raw.post.should be_nil
       raw.delete.should be_nil

--- a/spec/swagger/objects/response_helper.cr
+++ b/spec/swagger/objects/response_helper.cr
@@ -1,0 +1,3 @@
+require "spec"
+
+SWAGGER_OK_RESPONSE = {"200" => Swagger::Objects::Response.new "OK"}

--- a/src/swagger/action.cr
+++ b/src/swagger/action.cr
@@ -1,3 +1,8 @@
+require "./objects/path_item"
+require "./request"
+require "./response"
+require "./error"
+
 module Swagger
   # Define a action
   #
@@ -18,7 +23,11 @@ module Swagger
     property authorization
     property deprecated
 
-    def initialize(@method : String, @route : String, @responses : Array(Response), @summary : String? = nil, @parameters : Array(Parameter)? = nil,
+    def initialize(@method : String,
+                   @route : String,
+                   @responses : Array(Response),
+                   @summary : String? = nil,
+                   @parameters : Array(Parameter)? = nil,
                    @description : String? = nil, @request : Request? = nil,
                    @authorization = false, @deprecated = false)
       unless Objects::PathItem::METHODS.includes?(@method.downcase)

--- a/src/swagger/action.cr
+++ b/src/swagger/action.cr
@@ -18,8 +18,8 @@ module Swagger
     property authorization
     property deprecated
 
-    def initialize(@method : String, @route : String, @summary : String? = nil, @parameters : Array(Parameter)? = nil,
-                   @description : String? = nil, @request : Request? = nil, @responses : Array(Response)? = nil,
+    def initialize(@method : String, @route : String, @responses : Array(Response), @summary : String? = nil, @parameters : Array(Parameter)? = nil,
+                   @description : String? = nil, @request : Request? = nil,
                    @authorization = false, @deprecated = false)
       unless Objects::PathItem::METHODS.includes?(@method.downcase)
         raise UndefinedMethod.new("Undefined method `#{@method}`, avaiabled in #{Objects::PathItem::METHODS}.")

--- a/src/swagger/controller.cr
+++ b/src/swagger/controller.cr
@@ -1,3 +1,6 @@
+require "./action"
+require "./objects/external_docs"
+
 module Swagger
   # Define a controller
   #

--- a/src/swagger/objects/encoding.cr
+++ b/src/swagger/objects/encoding.cr
@@ -1,3 +1,7 @@
+require "json"
+
+require "./header"
+
 module Swagger::Objects
   # Encoding Object
   #

--- a/src/swagger/objects/media_type.cr
+++ b/src/swagger/objects/media_type.cr
@@ -1,5 +1,6 @@
 require "json"
 
+require "./schema"
 require "./example"
 require "./encoding"
 

--- a/src/swagger/objects/media_type.cr
+++ b/src/swagger/objects/media_type.cr
@@ -1,3 +1,8 @@
+require "json"
+
+require "./example"
+require "./encoding"
+
 module Swagger::Objects
   # Media Type Object
   #

--- a/src/swagger/objects/operation.cr
+++ b/src/swagger/objects/operation.cr
@@ -46,8 +46,7 @@ module Swagger::Objects
     end
 
     private def self.responses(action)
-      return unless responses = action.responses
-      responses.each_with_object(Hash(String, Response).new) do |response, obj|
+      action.responses.each_with_object(Hash(String, Response).new) do |response, obj|
         obj[response.code] = Response.new(response.description, content: response.content)
       end
     end

--- a/src/swagger/objects/operation.cr
+++ b/src/swagger/objects/operation.cr
@@ -64,11 +64,12 @@ module Swagger::Objects
     @[JSON::Field(key: "requestBody")]
     getter request_body : RequestBody? = nil
 
-    getter responses : Hash(String, Response)? = nil
+    # List of possible responses as they are returned from executing this operation.
+    getter responses : Hash(String, Response)
     getter deprecated : Bool = false
     getter security : Array(Hash(String, Array(String)))? = nil
 
-    # TODO: Add instace vars to initialize
+    # TODO: Add instance vars to initialize
     getter servers : Array(Server)? = nil
 
     @[JSON::Field(key: "externalDocs")]
@@ -77,8 +78,8 @@ module Swagger::Objects
     @[JSON::Field(key: "operationId")]
     getter operation_id : String? = nil
 
-    def initialize(@summary : String? = nil, @description : String? = nil, @tags : Array(String)? = nil,
-                   @parameters : Array(Parameter)? = nil, @request_body : RequestBody? = nil, @responses : Hash(String, Response)? = nil,
+    def initialize(@responses : Hash(String, Response), @summary : String? = nil, @description : String? = nil, @tags : Array(String)? = nil,
+                   @parameters : Array(Parameter)? = nil, @request_body : RequestBody? = nil,
                    @deprecated : Bool = false, @security : Array(Hash(String, Array(String)))? = nil)
     end
   end

--- a/src/swagger/objects/operation.cr
+++ b/src/swagger/objects/operation.cr
@@ -1,3 +1,10 @@
+require "json"
+
+require "./parameter"
+require "./request_body"
+require "./response"
+require "./server"
+
 module Swagger::Objects
   # Operation Object
   #

--- a/src/swagger/objects/parameter.cr
+++ b/src/swagger/objects/parameter.cr
@@ -1,3 +1,7 @@
+require "json"
+
+require "./schema"
+
 module Swagger::Objects
   # Parameter Object
   #

--- a/src/swagger/objects/path_item.cr
+++ b/src/swagger/objects/path_item.cr
@@ -1,3 +1,6 @@
+require "json"
+require "./operation"
+
 module Swagger::Objects
   # Path Item Object
   #

--- a/src/swagger/objects/request_body.cr
+++ b/src/swagger/objects/request_body.cr
@@ -1,3 +1,7 @@
+require "json"
+
+require "./media_type"
+
 module Swagger::Objects
   # Request Body Object
   #

--- a/src/swagger/objects/response.cr
+++ b/src/swagger/objects/response.cr
@@ -1,3 +1,9 @@
+require "json"
+
+require "./header"
+require "./media_type"
+require "./link"
+
 module Swagger::Objects
   # Response Object
   #

--- a/src/swagger/objects/schema.cr
+++ b/src/swagger/objects/schema.cr
@@ -1,3 +1,7 @@
+require "json"
+
+require "./property"
+
 module Swagger::Objects
   # Schema Object
   #

--- a/src/swagger/response.cr
+++ b/src/swagger/response.cr
@@ -1,3 +1,5 @@
+require "./objects/media_type"
+
 module Swagger
   struct Response
     def self.new(code : String, description : String, reference name : String, content_type : String? = nil)
@@ -14,7 +16,7 @@ module Swagger
     property media_type
     property content_type : String
 
-    def initialize(@code : String, @description : String, @media_type : MediaType? = nil, content_type : String? = nil)
+    def initialize(@code : String, @description : String, @media_type : Objects::MediaType? = nil, content_type : String? = nil)
       @content_type = content_type || "application/json"
     end
 


### PR DESCRIPTION
According to the OpenAPI specification (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject), the operation's `responses` is indicated as **REQUIRED**.