### PR TITLE
Move OpenAPI version to Document

### DIFF
--- a/src/swagger.cr
+++ b/src/swagger.cr
@@ -2,8 +2,6 @@ require "json"
 require "./swagger/*"
 
 module Swagger
-  VERSION = "0.1.1"
-
   alias Document = Objects::Document
   alias Info = Objects::Info
   alias Contact = Objects::Info::Contact

--- a/src/swagger.cr
+++ b/src/swagger.cr
@@ -4,9 +4,6 @@ require "./swagger/*"
 module Swagger
   VERSION = "0.1.1"
 
-  OPENAPI_MAJAR_VERSION = "3"
-  OPENAPI_VERSION       = "3.0.1"
-
   alias Document = Objects::Document
   alias Info = Objects::Info
   alias Contact = Objects::Info::Contact

--- a/src/swagger/http/handlers/api.cr
+++ b/src/swagger/http/handlers/api.cr
@@ -1,15 +1,14 @@
 require "json"
+require "semantic_version"
 
 module Swagger::HTTP
   class APIHandler
     include Swagger::HTTP::Handler
 
-    def self.new(document : Document, endpoint : String, debug_mode = true)
-      json = document.to_json
-      new(json, endpoint)
-    end
-
-    def initialize(@json : String, @endpoint : String, @debug_mode = true)
+    def initialize(document : Document, @endpoint : String, @debug_mode = true)
+      major = SemanticVersion.parse(document.openapi_version).major
+      @swagger_path = "/v#{major}/swagger.json"
+      @json = document.to_json
     end
 
     def call(context)
@@ -20,17 +19,13 @@ module Swagger::HTTP
     end
 
     def match?(context)
-      match_router?(context, swagger_path)
+      match_router?(context, @swagger_path)
     end
 
     def api_url
       uri = URI.parse(@endpoint)
-      uri.path = swagger_path
+      uri.path = @swagger_path
       uri.to_s
-    end
-
-    private def swagger_path
-      "/v#{Swagger::OPENAPI_MAJAR_VERSION}/swagger.json"
     end
   end
 end

--- a/src/swagger/objects/document.cr
+++ b/src/swagger/objects/document.cr
@@ -2,7 +2,8 @@ module Swagger::Objects
   struct Document
     include JSON::Serializable
 
-    property openapi = Swagger::OPENAPI_VERSION
+    @[JSON::Field(key: "openapi")]
+    property openapi_version : String = "3.0.1"
     property info : Objects::Info
     property paths : Hash(String, Objects::PathItem)
     property servers : Array(Objects::Server)? = nil


### PR DESCRIPTION
It prevents a dependency between Document and the whole project.

One other thing is the major version is automatically taken from the full version, thanks to `SemanticVersion`.