### PR TITLE
Bump OpenAPI version to 3.0.3

### DIFF
--- a/src/swagger/objects/components.cr
+++ b/src/swagger/objects/components.cr
@@ -1,7 +1,7 @@
 module Swagger::Objects
   # Components Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#componentsObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#componentsObject
   struct Components
     include JSON::Serializable
 

--- a/src/swagger/objects/document.cr
+++ b/src/swagger/objects/document.cr
@@ -3,7 +3,7 @@ module Swagger::Objects
     include JSON::Serializable
 
     @[JSON::Field(key: "openapi")]
-    property openapi_version : String = "3.0.1"
+    property openapi_version : String = "3.0.3"
     property info : Objects::Info
     property paths : Hash(String, Objects::PathItem)
     property servers : Array(Objects::Server)? = nil

--- a/src/swagger/objects/encoding.cr
+++ b/src/swagger/objects/encoding.cr
@@ -5,7 +5,7 @@ require "./header"
 module Swagger::Objects
   # Encoding Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#encodingObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#encodingObject
   struct Encoding
     include JSON::Serializable
 

--- a/src/swagger/objects/example.cr
+++ b/src/swagger/objects/example.cr
@@ -1,7 +1,7 @@
 module Swagger::Objects
   # Example Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#exampleObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#exampleObject
   struct Example
     include JSON::Serializable
 

--- a/src/swagger/objects/external_docs.cr
+++ b/src/swagger/objects/external_docs.cr
@@ -1,7 +1,7 @@
 module Swagger::Objects
   # External Documentation Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#externalDocumentationObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#externalDocumentationObject
   struct ExternalDocs
     include JSON::Serializable
 

--- a/src/swagger/objects/header.cr
+++ b/src/swagger/objects/header.cr
@@ -1,7 +1,7 @@
 module Swagger::Objects
   # Header Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#headerObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#headerObject
   struct Header
     include JSON::Serializable
 

--- a/src/swagger/objects/info.cr
+++ b/src/swagger/objects/info.cr
@@ -1,7 +1,7 @@
 module Swagger::Objects
   # Info Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#infoObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#infoObject
   struct Info
     include JSON::Serializable
 
@@ -21,7 +21,7 @@ module Swagger::Objects
 
     # Contact Object
     #
-    # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#contactObject
+    # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#contactObject
     struct Contact
       include JSON::Serializable
 
@@ -35,7 +35,7 @@ module Swagger::Objects
 
     # License Object
     #
-    # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#licenseObject
+    # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#licenseObject
     struct License
       include JSON::Serializable
 

--- a/src/swagger/objects/link.cr
+++ b/src/swagger/objects/link.cr
@@ -1,7 +1,7 @@
 module Swagger::Objects
   # Link Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#linkObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#linkObject
   struct Link
     include JSON::Serializable
 

--- a/src/swagger/objects/media_type.cr
+++ b/src/swagger/objects/media_type.cr
@@ -7,7 +7,7 @@ require "./encoding"
 module Swagger::Objects
   # Media Type Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#mediaTypeObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#mediaTypeObject
   struct MediaType
     include JSON::Serializable
 

--- a/src/swagger/objects/operation.cr
+++ b/src/swagger/objects/operation.cr
@@ -8,7 +8,7 @@ require "./server"
 module Swagger::Objects
   # Operation Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#operationObject
   struct Operation
     include JSON::Serializable
 

--- a/src/swagger/objects/parameter.cr
+++ b/src/swagger/objects/parameter.cr
@@ -5,11 +5,11 @@ require "./schema"
 module Swagger::Objects
   # Parameter Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#parameterObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#parameterObject
   struct Parameter
     include JSON::Serializable
 
-    # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#parameter-locations
+    # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#parameter-locations
     enum Location
       Path
       Query

--- a/src/swagger/objects/path_item.cr
+++ b/src/swagger/objects/path_item.cr
@@ -4,7 +4,7 @@ require "./operation"
 module Swagger::Objects
   # Path Item Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#pathItemObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#pathItemObject
   struct PathItem
     include JSON::Serializable
 

--- a/src/swagger/objects/request_body.cr
+++ b/src/swagger/objects/request_body.cr
@@ -5,7 +5,7 @@ require "./media_type"
 module Swagger::Objects
   # Request Body Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#requestBodyObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#requestBodyObject
   struct RequestBody
     include JSON::Serializable
 

--- a/src/swagger/objects/response.cr
+++ b/src/swagger/objects/response.cr
@@ -7,7 +7,7 @@ require "./link"
 module Swagger::Objects
   # Response Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#responsesObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#responsesObject
   struct Response
     include JSON::Serializable
 

--- a/src/swagger/objects/schema.cr
+++ b/src/swagger/objects/schema.cr
@@ -5,21 +5,15 @@ require "./property"
 module Swagger::Objects
   # Schema Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#schemaObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#schemaObject
   struct Schema
     include JSON::Serializable
-
-    # DATA_TYPES = {
-    #   "integer" => ["int32", "int64"],
-    #   "number" => ["float", "double"],
-    #   "string" => ["byte", "binary", "date", "date-time", "password", "base64", "uuid"],
-    #   "boolean" => nil,
-    # }
 
     def self.use_reference(name : String)
       new(ref: "#/components/schemas/#{name}")
     end
 
+    # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#dataTypes
     getter type : String? = nil
     getter format : String? = nil
     getter required : Array(String)? = nil

--- a/src/swagger/objects/security_scheme.cr
+++ b/src/swagger/objects/security_scheme.cr
@@ -1,7 +1,7 @@
 module Swagger::Objects
   # SecurityScheme Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#componentsSecuritySchemes
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#componentsSecuritySchemes
   struct SecurityScheme
     include JSON::Serializable
 

--- a/src/swagger/objects/server.cr
+++ b/src/swagger/objects/server.cr
@@ -1,7 +1,7 @@
 module Swagger::Objects
   # Server Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#serverObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#serverObject
   struct Server
     include JSON::Serializable
 
@@ -15,7 +15,7 @@ module Swagger::Objects
 
     # ServerVariable Object
     #
-    # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#serverVariableObject
+    # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#serverVariableObject
     struct Variable
       include JSON::Serializable
 

--- a/src/swagger/objects/tag.cr
+++ b/src/swagger/objects/tag.cr
@@ -1,7 +1,7 @@
 module Swagger::Objects
   # Tag Object
   #
-  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#tagObject
+  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#tagObject
   struct Tag
     include JSON::Serializable
 


### PR DESCRIPTION
I have diffed between https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md and https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md - not much change at the end.