### PR TITLE
Fixes quick look example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ builder = Swagger::Builder.new(
   title: "App API",
   version: "1.0.0",
   description: "This is a sample api for users",
-  terms: "http://yourapp.com/terms",
+  terms_url: "http://yourapp.com/terms",
   contact: Swagger::Contact.new("icyleaf", "icyleaf.cn@gmail.com", "http://icyleaf.com"),
   license: Swagger::License.new("MIT", "https://github.com/icyleaf/swagger/blob/master/LICENSE"),
   authorizations: [
@@ -35,21 +35,23 @@ builder = Swagger::Builder.new(
 )
 
 builder.add(Swagger::Controller.new("Users", "User resources", [
-  Swagger::Action.new("get", "/users", "All users"),
-  Swagger::Action.new("get", "/users/{id}", "Get user by id", parameters: [
+  Swagger::Action.new("get", "/users", description: "All users", responses: [
+    Swagger::Response.new("200", "Success response")
+  ]),
+  Swagger::Action.new("get", "/users/{id}", description: "Get user by id", parameters: [
     Swagger::Parameter.new("id", "path")
   ], responses: [
     Swagger::Response.new("200", "Success response"),
     Swagger::Response.new("404", "Not found user")
   ], authorization: true),
-  Swagger::Action.new("post", "/users", "Create User", responses: [
+  Swagger::Action.new("post", "/users", description: "Create User", responses: [
     Swagger::Response.new("201", "Return user resource after created"),
     Swagger::Response.new("401", "Unauthorizated")
   ], authorization: false)
 ]))
 
 document = builder.built
-p document
+puts document.to_json
 ```
 
 ## Structure

--- a/src/swagger/http/handlers/api.cr
+++ b/src/swagger/http/handlers/api.cr
@@ -4,7 +4,9 @@ require "semantic_version"
 module Swagger::HTTP
   class APIHandler
     include Swagger::HTTP::Handler
-
+    
+    @json : String
+    
     def initialize(document : Document, @endpoint : String, @debug_mode = true)
       major = SemanticVersion.parse(document.openapi_version).major
       @swagger_path = "/v#{major}/swagger.json"


### PR DESCRIPTION
Updates the Quick Look example with something that works with the current API.

Changed the output to JSON which should help people generating the a JSON OpenAPI file, which to me it helps you get started, since it's familiar.