### PR TITLE
Customize swagger_path, `@debug` defaults to false

### DIFF
--- a/src/swagger/http/handlers/api.cr
+++ b/src/swagger/http/handlers/api.cr
@@ -5,11 +5,14 @@ module Swagger::HTTP
   class APIHandler
     include Swagger::HTTP::Handler
 
+    @swagger_path : String
     @json : String
 
-    def initialize(document : Document, @endpoint : String, @debug_mode = true)
+    def initialize(document : Document, @endpoint : String, @debug_mode = false, swagger_path : String? = nil)
       major = SemanticVersion.parse(document.openapi_version).major
-      @swagger_path = "/v#{major}/swagger.json"
+
+      @swagger_path = swagger_path.is_a?(String) ? swagger_path : "/v#{major}/swagger.json"
+
       @json = document.to_json
     end
 


### PR DESCRIPTION
Just started using this project, very glad it exists and is quite _clean_ :)

I wanted to customize the place the `swagger.json` file ends up on the path (my route api is `/api/v#{VERSION}/`, so quite close to the default), and it seems there's not a way to currently do that.

Also noticed that `@debug` defaults to `true`, noticed it was opening up some Cors restrictions, maybe if defaulting it to true is what is expected, it can be renamed to something like `permissive_cors`?