### PR TITLE
Update security_scheme.cr

### DIFF
--- a/src/swagger/objects/security_scheme.cr
+++ b/src/swagger/objects/security_scheme.cr
@@ -25,7 +25,7 @@ module Swagger::Objects
     end
 
     def self.bearer(description : String? = nil, format : String? = nil)
-      new("http", description, parameter_location: "header", scheme: "basic", bearer_format: format)
+      new("http", description, parameter_location: "header", scheme: "bearer", bearer_format: format)
     end
 
     def self.api_key(name : String, location : String, description : String? = nil)


### PR DESCRIPTION
The scheme was set to `basic` which resulted into a `basic authorization` popup showing instead of a header input value, I updated the scheme and it worked by monkey patching the library.

```ruby
module Swagger::Objects
  # SecurityScheme Object
  #
  # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#componentsSecuritySchemes
  struct SecurityScheme
    def self.bearer(description : String? = nil, format : String? = nil)
      new("http", description, parameter_location: "header", scheme: "bearer", bearer_format: format)
    end
  end
end
```