### PR TITLE
Add array support to Swagger::Object and Swagger::Property

### DIFF
--- a/spec/swagger/object_spec.cr
+++ b/spec/swagger/object_spec.cr
@@ -13,7 +13,33 @@ describe Swagger::Object do
       raw = Swagger::Object.new("User", "object", properties)
       raw.name.should eq "User"
       raw.type.should eq "object"
-      raw.properties.size.should eq 5
+      raw.properties.should_not be_nil
+      raw.properties.try &.size.should eq 5
+    end
+
+    it "should supports the type array with items as an object" do
+      raw = Swagger::Object.new(
+        "CommentList",
+        "array",
+        items: Swagger::Object.new(
+          "Comment",
+          "object",
+        )
+      )
+      raw.type.should eq("array")
+      raw.properties.should be_nil
+      raw.items.class.should eq(Swagger::Object)
+    end
+
+    it "should supports the type array with items as a ref" do
+      raw = Swagger::Object.new(
+        "CommentList",
+        "array",
+        items: "Comment",
+      )
+      raw.type.should eq("array")
+      raw.properties.should be_nil
+      raw.items.should eq("Comment")
     end
   end
 end

--- a/spec/swagger/property_spec.cr
+++ b/spec/swagger/property_spec.cr
@@ -12,5 +12,25 @@ describe Swagger::Property do
       raw.required.should be_nil
       raw.example.should be_nil
     end
+
+    it "should supports the array type with items as an Object" do
+      raw = Swagger::Property.new(
+        "comments",
+        "array",
+        items: Swagger::Object.new("Comment", "object")
+      )
+      raw.type.should eq("array")
+      raw.items.class.should eq(Swagger::Object)
+    end
+
+    it "should supports the array type with items as a ref" do
+      raw = Swagger::Property.new(
+        "comments",
+        "array",
+        items: "Comment",
+      )
+      raw.type.should eq("array")
+      raw.items.should eq("Comment")
+    end
   end
 end

--- a/src/swagger/object.cr
+++ b/src/swagger/object.cr
@@ -12,12 +12,14 @@ module Swagger
   #   Swagger::Property.new("bio", "Personal bio"),
   # ])
   # ```
-  struct Object
+  class Object
     property name
     property type
     property properties
+    property items
 
-    def initialize(@name : String, @type : String, @properties : Array(Property))
+    def initialize(@name : String, @type : String, @properties : Array(Property)? = nil,
+                   @items : (self | String)? = nil)
     end
   end
 end

--- a/src/swagger/objects/property.cr
+++ b/src/swagger/objects/property.cr
@@ -3,12 +3,13 @@ module Swagger::Objects
     include JSON::Serializable
 
     getter type : String
+    getter items : Schema? = nil
     getter description : String? = nil
     getter default : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter example : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter required : Bool? = nil
 
-    def initialize(@type : String, @description : String? = nil,
+    def initialize(@type : String, @description : String? = nil, @items : Schema? = nil,
                    @default : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @required : Bool? = nil)

--- a/src/swagger/property.cr
+++ b/src/swagger/property.cr
@@ -3,13 +3,15 @@ module Swagger
     property name
     property type
     property format
+    property items
     property description
     property default_value
     property example
     property required
 
     def initialize(@name : String, @type : String = "string", @format : String? = nil,
-                   @description : String? = nil, @default_value : (String | Int32 | Int64 | Float64 | Bool)? = nil,
+                   @items : (Object | String)? = nil, @description : String? = nil,
+                   @default_value : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @required : Bool? = nil)
     end


### PR DESCRIPTION
This adds the support of array objects, or array properties. It allows a user to do:
```Crystal
    builder.add(
      Swagger::Object.new(
        "SomethingList",
        "array",
        items: "Something",
      ),
    )
```

or:
```Crystal
    builder.add(
      Swagger::Object.new(
        "Post",
        "object",
        [
          Swagger::Property.new("id", "integer", "int32", example: 1),
          Swagger::Property.new("comments", "array", items: "Comment"),
        ]
      )
    )
```

I used refs here but `items` can also contains a `Swagger::Object`.

Tests to come.