### PR TITLE
Property ref

### DIFF
--- a/spec/swagger/object_spec.cr
+++ b/spec/swagger/object_spec.cr
@@ -13,7 +13,33 @@ describe Swagger::Object do
       raw = Swagger::Object.new("User", "object", properties)
       raw.name.should eq "User"
       raw.type.should eq "object"
-      raw.properties.size.should eq 5
+      raw.properties.should_not be_nil
+      raw.properties.try &.size.should eq 5
+    end
+
+    it "should supports the type array with items as an object" do
+      raw = Swagger::Object.new(
+        "CommentList",
+        "array",
+        items: Swagger::Object.new(
+          "Comment",
+          "object",
+        )
+      )
+      raw.type.should eq("array")
+      raw.properties.should be_nil
+      raw.items.class.should eq(Swagger::Object)
+    end
+
+    it "should supports the type array with items as a ref" do
+      raw = Swagger::Object.new(
+        "CommentList",
+        "array",
+        items: "Comment",
+      )
+      raw.type.should eq("array")
+      raw.properties.should be_nil
+      raw.items.should eq("Comment")
     end
   end
 end

--- a/spec/swagger/property_spec.cr
+++ b/spec/swagger/property_spec.cr
@@ -12,5 +12,25 @@ describe Swagger::Property do
       raw.required.should be_nil
       raw.example.should be_nil
     end
+
+    it "should supports the array type with items as an Object" do
+      raw = Swagger::Property.new(
+        "comments",
+        "array",
+        items: Swagger::Object.new("Comment", "object")
+      )
+      raw.type.should eq("array")
+      raw.items.class.should eq(Swagger::Object)
+    end
+
+    it "should supports the array type with items as a ref" do
+      raw = Swagger::Property.new(
+        "comments",
+        "array",
+        items: "Comment",
+      )
+      raw.type.should eq("array")
+      raw.items.should eq("Comment")
+    end
   end
 end

--- a/src/swagger/builder.cr
+++ b/src/swagger/builder.cr
@@ -129,7 +129,9 @@ module Swagger
     end
 
     private def build_property(property : Property) : Objects::Property
-      if property.type == "array"
+      if ref = property.ref
+        Objects::Property.use_reference(ref)
+      elsif property.type == "array"
         if items = property.items
           if items.is_a?(String)
             prop_items = Objects::Schema.use_reference(items)

--- a/src/swagger/object.cr
+++ b/src/swagger/object.cr
@@ -12,12 +12,14 @@ module Swagger
   #   Swagger::Property.new("bio", "Personal bio"),
   # ])
   # ```
-  struct Object
+  class Object
     property name
     property type
     property properties
+    property items
 
-    def initialize(@name : String, @type : String, @properties : Array(Property))
+    def initialize(@name : String, @type : String, @properties : Array(Property)? = nil,
+                   @items : (self | String)? = nil)
     end
   end
 end

--- a/src/swagger/objects/property.cr
+++ b/src/swagger/objects/property.cr
@@ -2,17 +2,24 @@ module Swagger::Objects
   struct Property
     include JSON::Serializable
 
-    getter type : String
+    def self.use_reference(name : String)
+      new(ref: "#/components/schemas/#{name}")
+    end
+
+    getter type : String? = nil
     getter items : Schema? = nil
     getter description : String? = nil
     getter default : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter example : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter required : Bool? = nil
 
-    def initialize(@type : String, @description : String? = nil, @items : Schema? = nil,
+    @[JSON::Field(key: "$ref")]
+    getter ref : String? = nil
+
+    def initialize(@type : String? = nil, @description : String? = nil, @items : Schema? = nil,
                    @default : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
-                   @required : Bool? = nil)
+                   @required : Bool? = nil, @ref : String? = nil,)
     end
   end
 end

--- a/src/swagger/objects/property.cr
+++ b/src/swagger/objects/property.cr
@@ -3,12 +3,13 @@ module Swagger::Objects
     include JSON::Serializable
 
     getter type : String
+    getter items : Schema? = nil
     getter description : String? = nil
     getter default : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter example : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter required : Bool? = nil
 
-    def initialize(@type : String, @description : String? = nil,
+    def initialize(@type : String, @description : String? = nil, @items : Schema? = nil,
                    @default : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @required : Bool? = nil)

--- a/src/swagger/property.cr
+++ b/src/swagger/property.cr
@@ -8,12 +8,13 @@ module Swagger
     property default_value
     property example
     property required
+    property ref
 
     def initialize(@name : String, @type : String = "string", @format : String? = nil,
                    @items : (Object | String)? = nil, @description : String? = nil,
                    @default_value : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
-                   @required : Bool? = nil)
+                   @required : Bool? = nil, @ref : String? = nil)
     end
   end
 end

--- a/src/swagger/property.cr
+++ b/src/swagger/property.cr
@@ -3,13 +3,15 @@ module Swagger
     property name
     property type
     property format
+    property items
     property description
     property default_value
     property example
     property required
 
     def initialize(@name : String, @type : String = "string", @format : String? = nil,
-                   @description : String? = nil, @default_value : (String | Int32 | Int64 | Float64 | Bool)? = nil,
+                   @items : (Object | String)? = nil, @description : String? = nil,
+                   @default_value : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @required : Bool? = nil)
     end


### PR DESCRIPTION
This PR based on the work done on #23. It allows to use a ref in a property object, as defined by the OpenAPI v3 spec.

```Crystal
builder.add(Swagger::Object.new("User", "object"))
builder.add(
  Swagger::Object.new(
    "Post",
    "object"
    [
      Swagger::Property("content"),
      Swagger::Property("author", "object", ref: "User"),
    ],
)
```


I think it is obvious that I am duplicating the code that was in `Swagger::Objects::Schema` to `Swagger::Objects::Property`. Actually in the OpenAPI v3 spec they are both the same. The `properties` dict is `Hash(String, Schema)`.

So I would like to propose to merge those two types. For the user facing API we can keep the `Swagger::Object` and `Swagger::Property` distinction, but for the OpenAPI generation I don't think it brings any advantage.