### PR TITLE
Improve Swagger Object creation

### DIFF
--- a/spec/swagger/object_spec.cr
+++ b/spec/swagger/object_spec.cr
@@ -17,6 +17,13 @@ enum VCS
   FOSSIL
 end
 
+struct Example::SelfRef
+  property refs
+
+  def initialize(@refs : Array(Example::SelfRef) | Nil)
+  end
+end
+
 struct Project
   property id, name, description, vcs, open_source, author
 
@@ -95,6 +102,22 @@ describe Swagger::Object do
           example: "Swagger contains a OpenAPI / Swagger universal documentation generator and HTTP server handler.",
           required: false
         ),
+      ]
+    end
+
+    it "should generate schema of object with self ref" do
+      raw = Swagger::Object.create_from_instance(
+        Example::SelfRef.new(
+          [
+            Example::SelfRef.new(nil),
+          ]
+        )
+      )
+      raw.name.should eq "exampleSelfRef"
+      raw.type.should eq "object"
+      raw.items.should be nil
+      raw.properties.should eq [
+        Swagger::Property.new("refs", "array", required: false, items: "exampleSelfRef"),
       ]
     end
 

--- a/spec/swagger/object_spec.cr
+++ b/spec/swagger/object_spec.cr
@@ -1,5 +1,12 @@
 require "../spec_helper"
 
+struct Project
+  property id, name, description, vcs, open_source
+
+  def initialize(@id : Int32, @name : String, @vcs : String, @open_source : Bool, @description : String? = nil)
+  end
+end
+
 describe Swagger::Object do
   describe "#new" do
     it "should works" do
@@ -40,6 +47,25 @@ describe Swagger::Object do
       raw.type.should eq("array")
       raw.properties.should be_nil
       raw.items.should eq("Comment")
+    end
+
+    it "should generate schema of object from object instance" do
+      raw = Swagger::Object.create_from_instance(
+        Project.new(1, "swagger", "git", true, "Swagger contains a OpenAPI / Swagger universal documentation generator and HTTP server handler.")
+      )
+      raw.name.should eq "Project"
+      raw.type.should eq "object"
+      raw.properties.should eq [
+        Swagger::Property.new("id", "integer", "int32", example: 1, required: true),
+        Swagger::Property.new("name", example: "swagger", required: true),
+        Swagger::Property.new("vcs", example: "git", required: true),
+        Swagger::Property.new("open_source", "boolean", example: true, required: true),
+        Swagger::Property.new(
+          "description",
+          example: "Swagger contains a OpenAPI / Swagger universal documentation generator and HTTP server handler.",
+          required: false
+        ),
+      ]
     end
   end
 end

--- a/spec/swagger/object_spec.cr
+++ b/spec/swagger/object_spec.cr
@@ -1,6 +1,9 @@
 require "../spec_helper"
 
-struct Author
+module Example
+end
+
+struct Example::Author
   property name
 
   def initialize(@name : String)
@@ -17,7 +20,7 @@ end
 struct Project
   property id, name, description, vcs, open_source, author
 
-  def initialize(@id : Int32, @name : String, @vcs : VCS, @open_source : Bool, @author : Author, @description : String? = nil)
+  def initialize(@id : Int32, @name : String, @vcs : VCS, @open_source : Bool, @author : Example::Author, @description : String? = nil)
   end
 end
 
@@ -64,19 +67,19 @@ describe Swagger::Object do
     end
 
     it "should generate schema of object with ref from object instance" do
-      author = Author.new("icyleaf")
+      author = Example::Author.new("icyleaf")
       raw = Swagger::Object.create_from_instance(
         Project.new(1,
           "swagger", VCS::GIT, true,
           author,
           "Swagger contains a OpenAPI / Swagger universal documentation generator and HTTP server handler."),
         refs: {
-          "Author" => Swagger::Object.create_from_instance(
+          "exampleAuthor" => Swagger::Object.create_from_instance(
             author
           ),
         },
       )
-      raw.name.should eq "Project"
+      raw.name.should eq "project"
       raw.type.should eq "object"
       raw.items.should be nil
       raw.properties.should eq [
@@ -86,7 +89,7 @@ describe Swagger::Object do
           "GIT", "SUBVERSION", "MERCURIAL", "FOSSIL",
         ]),
         Swagger::Property.new("open_source", "boolean", example: true, required: true),
-        Swagger::Property.new("author", "object", required: true, ref: "Author"),
+        Swagger::Property.new("author", "object", required: true, ref: "exampleAuthor"),
         Swagger::Property.new(
           "description",
           example: "Swagger contains a OpenAPI / Swagger universal documentation generator and HTTP server handler.",
@@ -100,18 +103,18 @@ describe Swagger::Object do
         Swagger::Object.create_from_instance(
           Project.new(1,
             "swagger", VCS::GIT, true,
-            Author.new("icyleaf"),
+            Example::Author.new("icyleaf"),
             "Swagger contains a OpenAPI / Swagger universal documentation generator and HTTP server handler.")
         )
       end
     end
 
     it "shouldn't generate schema of object without correct ref from object instance" do
-      expect_raises(Swagger::Object::RefResolutionException, "Ref for Author not found") do
+      expect_raises(Swagger::Object::RefResolutionException, "Ref for Example::Author not found (Searched for followed name : exampleAuthor)") do
         Swagger::Object.create_from_instance(
           Project.new(1,
             "swagger", VCS::GIT, true,
-            Author.new("icyleaf"),
+            Example::Author.new("icyleaf"),
             "Swagger contains a OpenAPI / Swagger universal documentation generator and HTTP server handler."),
           refs: {"SomeStringAlias" => "string"},
         )

--- a/spec/swagger/object_spec.cr
+++ b/spec/swagger/object_spec.cr
@@ -64,12 +64,17 @@ describe Swagger::Object do
     end
 
     it "should generate schema of object with ref from object instance" do
+      author = Author.new("icyleaf")
       raw = Swagger::Object.create_from_instance(
         Project.new(1,
           "swagger", VCS::GIT, true,
-          Author.new("icyleaf"),
+          author,
           "Swagger contains a OpenAPI / Swagger universal documentation generator and HTTP server handler."),
-        refs: {Author => "Author"},
+        refs: {
+          "Author" => Swagger::Object.create_from_instance(
+            author
+          ),
+        },
       )
       raw.name.should eq "Project"
       raw.type.should eq "object"
@@ -108,7 +113,7 @@ describe Swagger::Object do
             "swagger", VCS::GIT, true,
             Author.new("icyleaf"),
             "Swagger contains a OpenAPI / Swagger universal documentation generator and HTTP server handler."),
-          refs: {Hash => "Hash"},
+          refs: {"SomeStringAlias" => "string"},
         )
       end
     end

--- a/src/swagger/builder.cr
+++ b/src/swagger/builder.cr
@@ -153,6 +153,7 @@ module Swagger
           type: property.type,
           description: property.description,
           example: property.example,
+          enum_values: property.enum_values,
         )
       end
     end

--- a/src/swagger/builder.cr
+++ b/src/swagger/builder.cr
@@ -129,7 +129,9 @@ module Swagger
     end
 
     private def build_property(property : Property) : Objects::Property
-      if property.type == "array"
+      if ref = property.ref
+        Objects::Property.use_reference(ref)
+      elsif property.type == "array"
         if items = property.items
           if items.is_a?(String)
             prop_items = Objects::Schema.use_reference(items)

--- a/src/swagger/builder.cr
+++ b/src/swagger/builder.cr
@@ -111,7 +111,11 @@ module Swagger
       if object.type == "array"
         if items = object.items
           if items.is_a?(String)
-            schema_items = Objects::Schema.use_reference(items)
+            if [ "string", "integer", "number", "boolean" ].includes?(items)
+              schema_items = Objects::Schema.default_type(items)
+            else
+              schema_items = Objects::Schema.use_reference(items)
+            end
           else
             schema_items = build_schema(items)
           end

--- a/src/swagger/http/handler.cr
+++ b/src/swagger/http/handler.cr
@@ -5,9 +5,10 @@ require "http/server/handler"
 module Swagger::HTTP::Handler
   macro included
     include ::HTTP::Handler
+
     def not_found(context)
       response_with(context, {
-        message: "not_found"
+        message: "not_found",
       }, status_code: 404)
     end
 

--- a/src/swagger/object.cr
+++ b/src/swagger/object.cr
@@ -21,5 +21,32 @@ module Swagger
     def initialize(@name : String, @type : String, @properties : Array(Property)? = nil,
                    @items : (self | String)? = nil)
     end
+
+    def self.create_from_instance(reflecting instance : T, custom_name : String? = nil) forall T
+      {% begin %}
+        properties = [] of Property
+        {% for ivar in T.instance.instance_vars %}
+          {{ iname = ivar.name.stringify }}
+          swagger_data_type = Utils::SwaggerDataType.create_from_class({{ ivar.type }})
+          {{ irequired = !ivar.type.union? }}
+          value = {% if T.class? || T.struct? %} instance.{{ ivar.name }} {% else %} {{ ivar.default_value.stringify }} {% end %}
+          properties << Property.new(
+            {{ iname }},
+            swagger_data_type.type,
+            format: swagger_data_type.format,
+            {% if ivar.type <= String || ivar.type <= Int32 ||
+                    ivar.type <= Int64 || ivar.type <= Float64 ||
+                    ivar.type <= Bool %}
+              example: value,
+            {% else %}
+              example: value.to_s,
+            {% end %}
+            required: {{ irequired }}
+          )
+        {% end %}
+
+        self.new(custom_name ? custom_name.as(String) : instance.class.name, "object", properties)
+      {% end %}
+    end
   end
 end

--- a/src/swagger/objects/property.cr
+++ b/src/swagger/objects/property.cr
@@ -2,17 +2,24 @@ module Swagger::Objects
   struct Property
     include JSON::Serializable
 
-    getter type : String
+    def self.use_reference(name : String)
+      new(ref: "#/components/schemas/#{name}")
+    end
+
+    getter type : String? = nil
     getter items : Schema? = nil
     getter description : String? = nil
     getter default : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter example : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter required : Bool? = nil
 
-    def initialize(@type : String, @description : String? = nil, @items : Schema? = nil,
+    @[JSON::Field(key: "$ref")]
+    getter ref : String? = nil
+
+    def initialize(@type : String? = nil, @description : String? = nil, @items : Schema? = nil,
                    @default : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
-                   @required : Bool? = nil)
+                   @required : Bool? = nil, @ref : String? = nil,)
     end
   end
 end

--- a/src/swagger/objects/property.cr
+++ b/src/swagger/objects/property.cr
@@ -12,6 +12,8 @@ module Swagger::Objects
     getter default : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter example : (String | Int32 | Int64 | Float64 | Bool)? = nil
     getter required : Bool? = nil
+    @[JSON::Field(key: "enum")]
+    getter enum_values : Array(String)? = nil
 
     @[JSON::Field(key: "$ref")]
     getter ref : String? = nil
@@ -19,7 +21,8 @@ module Swagger::Objects
     def initialize(@type : String? = nil, @description : String? = nil, @items : Schema? = nil,
                    @default : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
-                   @required : Bool? = nil, @ref : String? = nil,)
+                   @required : Bool? = nil, @ref : String? = nil,
+                   @enum_values : Array(String)? = nil)
     end
   end
 end

--- a/src/swagger/objects/schema.cr
+++ b/src/swagger/objects/schema.cr
@@ -13,6 +13,10 @@ module Swagger::Objects
       new(ref: "#/components/schemas/#{name}")
     end
 
+    def self.default_type(type : String)
+      new(type: type)
+    end
+
     # See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#dataTypes
     getter type : String? = nil
     getter format : String? = nil

--- a/src/swagger/property.cr
+++ b/src/swagger/property.cr
@@ -9,12 +9,14 @@ module Swagger
     property example
     property required
     property ref
+    property enum_values
 
     def initialize(@name : String, @type : String = "string", @format : String? = nil,
                    @items : (Object | String)? = nil, @description : String? = nil,
                    @default_value : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
-                   @required : Bool? = nil, @ref : String? = nil)
+                   @required : Bool? = nil, @ref : String? = nil,
+                   @enum_values : Array(String)? = nil)
     end
   end
 end

--- a/src/swagger/property.cr
+++ b/src/swagger/property.cr
@@ -8,12 +8,13 @@ module Swagger
     property default_value
     property example
     property required
+    property ref
 
     def initialize(@name : String, @type : String = "string", @format : String? = nil,
                    @items : (Object | String)? = nil, @description : String? = nil,
                    @default_value : (String | Int32 | Int64 | Float64 | Bool)? = nil,
                    @example : (String | Int32 | Int64 | Float64 | Bool)? = nil,
-                   @required : Bool? = nil)
+                   @required : Bool? = nil, @ref : String? = nil)
     end
   end
 end

--- a/src/swagger/utils.cr
+++ b/src/swagger/utils.cr
@@ -12,7 +12,7 @@ module Utils
           return self.create_from_class({{ T.union_types.find { |var| var != Nil } }})
         {% else %}
           # Cf https://swagger.io/specification/#data-types
-          {% if T <= String || T <= Nil %}
+          {% if T <= String %}
             swagger_type = "string"
             swagger_format = nil
           {% elsif T <= Int %}
@@ -37,7 +37,7 @@ module Utils
             swagger_type = "boolean"
             swagger_format = nil
           {% else %}
-            swagger_type = {{ T.stringify }}
+            swagger_type = "object"
             swagger_format = nil
           {% end %}
           return self.new(swagger_type, swagger_format)

--- a/src/swagger/utils.cr
+++ b/src/swagger/utils.cr
@@ -36,6 +36,9 @@ module Utils
           {% elsif T <= Bool %}
             swagger_type = "boolean"
             swagger_format = nil
+          {% elsif T <= Array %}
+            swagger_type = "array"
+            swagger_format = nil
           {% else %}
             swagger_type = "object"
             swagger_format = nil

--- a/src/swagger/utils.cr
+++ b/src/swagger/utils.cr
@@ -1,0 +1,48 @@
+module Utils
+  struct SwaggerDataType
+    property type : String
+    property format : String?
+
+    def initialize(@type : String, @format : String?)
+    end
+
+    def self.create_from_class(type : T.class) forall T
+      {% begin %}
+        {% if T.union? %}
+          return self.create_from_class({{ T.union_types.find { |var| var != Nil } }})
+        {% else %}
+          # Cf https://swagger.io/specification/#data-types
+          {% if T <= String || T <= Nil %}
+            swagger_type = "string"
+            swagger_format = nil
+          {% elsif T <= Int %}
+            swagger_type = "integer"
+            {% if T <= Int32 %}
+              swagger_format = "int32"
+            {% elsif T <= Int64 %}
+              swagger_format = "int64"
+            {% else %}
+              swagger_format = nil
+            {% end %}
+          {% elsif T <= Number %}
+            swagger_type = "number"
+            {% if T <= Float32 %}
+              swagger_format = "float"
+            {% elsif T <= Float64 %}
+              swagger_format = "double"
+            {% else %}
+              swagger_format = nil
+            {% end %}
+          {% elsif T <= Bool %}
+            swagger_type = "boolean"
+            swagger_format = nil
+          {% else %}
+            swagger_type = {{ T.stringify }}
+            swagger_format = nil
+          {% end %}
+          return self.new(swagger_type, swagger_format)
+        {% end %}
+      {% end %}
+    end
+  end
+end

--- a/src/swagger/utils.cr
+++ b/src/swagger/utils.cr
@@ -17,9 +17,9 @@ module Utils
             swagger_format = nil
           {% elsif T <= Int %}
             swagger_type = "integer"
-            {% if T <= Int32 %}
+            {% if T <= Int32 || T <= Int16 || T <= UInt16 || T <= Int8 || T <= UInt8 %}
               swagger_format = "int32"
-            {% elsif T <= Int64 %}
+            {% elsif T <= Int64 || T <= UInt32 %}
               swagger_format = "int64"
             {% else %}
               swagger_format = nil


### PR DESCRIPTION
Add creation of Swagger::Object by some object instance

(Related and insipred by #18)

Allow creation of Swagger::Object by something like that :
```crystal
struct User
  property id, nickname, username, email, bio

  def initialize(@id : String, @nickname : String, @username : String, @email : String, @bio : String? = nil)
  end
end

user = User.new(
  UUID.random.to_s, "icyleaf wang", "icyleaf", "icyleaf.cn@gmail.com", "Personal bio"
)

builder.add(Swagger::Object.create_from_instance(user))
```

P.S. : `src/swagger/http/handler.cr` was modified when the code formatting was executed via `crystal tool format src && crystal tool format spec`. I have therefore committed the formatting.